### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.5.0",
-        "phpunit/phpunit": "^4.8 || ^5.7",
+        "phpunit/phpunit": "^4.8.35 || ^5.7",
         "phpunit/php-code-coverage": "^2.2 || ^4.0 || ^5.2",
         "squizlabs/php_codesniffer": "^2.8",
         "symfony/console": "^3.2",

--- a/tests/Phug/DevTool/ApplicationTest.php
+++ b/tests/Phug/DevTool/ApplicationTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\DevTool;
 
+use PHPUnit\Framework\TestCase;
 use Phug\DevTool\Application;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Input\StringInput;
@@ -12,7 +13,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
  *
  * @coversDefaultClass \Phug\DevTool\Application
  */
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/Phug/DevTool/Command/CheckCommandTest.php
+++ b/tests/Phug/DevTool/Command/CheckCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\DevTool;
 
+use PHPUnit\Framework\TestCase;
 use Phug\DevTool\Application;
 use Phug\DevTool\Command\CheckCommand;
 use Symfony\Component\Console\Input\StringInput;
@@ -12,7 +13,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
  *
  * @coversDefaultClass \Phug\DevTool\Command\CheckCommand
  */
-class CheckCommandTest extends \PHPUnit_Framework_TestCase
+class CheckCommandTest extends TestCase
 {
     /**
      * @covers ::configure

--- a/tests/Phug/DevTool/Command/CodeStyleCheckCommandTest.php
+++ b/tests/Phug/DevTool/Command/CodeStyleCheckCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\DevTool;
 
+use PHPUnit\Framework\TestCase;
 use Phug\DevTool\Application;
 use Phug\DevTool\Command\CodeStyleCheckCommand;
 use Symfony\Component\Console\Input\StringInput;
@@ -12,7 +13,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
  *
  * @coversDefaultClass \Phug\DevTool\Command\CodeStyleCheckCommand
  */
-class CodeStyleCheckCommandTest extends \PHPUnit_Framework_TestCase
+class CodeStyleCheckCommandTest extends TestCase
 {
     /**
      * @covers ::configure

--- a/tests/Phug/DevTool/Command/CodeStyleFixCommandTest.php
+++ b/tests/Phug/DevTool/Command/CodeStyleFixCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\DevTool;
 
+use PHPUnit\Framework\TestCase;
 use Phug\DevTool\Command\CodeStyleFixCommand;
 
 /**
@@ -9,7 +10,7 @@ use Phug\DevTool\Command\CodeStyleFixCommand;
  *
  * @coversDefaultClass \Phug\DevTool\Command\CodeStyleFixCommand
  */
-class CodeStyleFixCommandTest extends \PHPUnit_Framework_TestCase
+class CodeStyleFixCommandTest extends TestCase
 {
     /**
      * @covers ::configure

--- a/tests/Phug/DevTool/Command/CoverageCheckCommandTest.php
+++ b/tests/Phug/DevTool/Command/CoverageCheckCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\DevTool;
 
+use PHPUnit\Framework\TestCase;
 use Phug\DevTool\Command\CoverageCheckCommand;
 
 /**
@@ -9,7 +10,7 @@ use Phug\DevTool\Command\CoverageCheckCommand;
  *
  * @coversDefaultClass \Phug\DevTool\Command\CoverageCheckCommand
  */
-class CoverageCheckCommandTest extends \PHPUnit_Framework_TestCase
+class CoverageCheckCommandTest extends TestCase
 {
     /**
      * @covers ::configure

--- a/tests/Phug/DevTool/Command/CoverageReportCommandTest.php
+++ b/tests/Phug/DevTool/Command/CoverageReportCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\DevTool;
 
+use PHPUnit\Framework\TestCase;
 use Phug\DevTool\Command\CoverageReportCommand;
 
 /**
@@ -9,7 +10,7 @@ use Phug\DevTool\Command\CoverageReportCommand;
  *
  * @coversDefaultClass \Phug\DevTool\Command\CoverageReportCommand
  */
-class CoverageReportCommandTest extends \PHPUnit_Framework_TestCase
+class CoverageReportCommandTest extends TestCase
 {
     /**
      * @covers ::configure

--- a/tests/Phug/DevTool/Command/InstallCommandTest.php
+++ b/tests/Phug/DevTool/Command/InstallCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\DevTool;
 
+use PHPUnit\Framework\TestCase;
 use Phug\DevTool\Command\InstallCommand;
 
 /**
@@ -9,7 +10,7 @@ use Phug\DevTool\Command\InstallCommand;
  *
  * @coversDefaultClass \Phug\DevTool\Command\InstallCommand
  */
-class InstallCommandTest extends \PHPUnit_Framework_TestCase
+class InstallCommandTest extends TestCase
 {
     /**
      * @covers ::configure

--- a/tests/Phug/DevTool/Command/UnitTestsRunCommandTest.php
+++ b/tests/Phug/DevTool/Command/UnitTestsRunCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\DevTool;
 
+use PHPUnit\Framework\TestCase;
 use Phug\DevTool\Application;
 use Phug\DevTool\Command\UnitTestsRunCommand;
 use Symfony\Component\Console\Input\StringInput;
@@ -12,7 +13,7 @@ use Symfony\Component\Console\Output\NullOutput;
  *
  * @coversDefaultClass \Phug\DevTool\Command\UnitTestsRunCommand
  */
-class UnitTestsRunCommandTest extends \PHPUnit_Framework_TestCase
+class UnitTestsRunCommandTest extends TestCase
 {
     private static function remove($entity)
     {


### PR DESCRIPTION
I've noticed that all `phug-php` packages use this one for tests. So, let's start from here the refactoring.

I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.